### PR TITLE
fix: Ctrl+click opens link in new tab

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -4,7 +4,7 @@ import { useDrag } from "react-dnd";
 import CardImage from "./CardImage";
 import { LinkData } from "../contexts/Links/reducer";
 import { LinksContext } from "../contexts/Links";
-import { navigateCurrentTab } from "../lib/webextension";
+import { navigateCurrentTab, openInNewTab } from "../lib/webextension";
 
 export const DragItemTypes = {
   CARD: "card",
@@ -44,6 +44,17 @@ export default function Card({
       }
     : {};
 
+  async function clickHandler(
+    event: React.MouseEvent<HTMLButtonElement>
+  ): Promise<void> {
+    if (event.ctrlKey) {
+      event.preventDefault();
+      await openInNewTab(url.toString());
+    } else {
+      await navigateCurrentTab(url.toString());
+    }
+  }
+
   return (
     <Button
       pos="absolute"
@@ -51,7 +62,7 @@ export default function Card({
       as="a"
       target="_self"
       href={url.toString()}
-      onClick={() => navigateCurrentTab(url.toString())}
+      onClick={clickHandler}
       variant="ghost"
       w="92%"
       minH="92%"

--- a/src/lib/webextension.ts
+++ b/src/lib/webextension.ts
@@ -21,6 +21,10 @@ export async function navigateCurrentTab(url: string): Promise<void> {
   window.close();
 }
 
+export async function openInNewTab(url: string): Promise<void> {
+  await browser.tabs.create({ url, active: false });
+}
+
 export async function getCurrentTab(): Promise<browser.Tabs.Tab> {
   const tabs = await browser.tabs.query({ active: true, currentWindow: true });
   return tabs[0];


### PR DESCRIPTION
Fixes a bug where the current tab was navigated to the link _and_ a new
tab was opened when ctrl+click was pressed.

This implementation keeps the extension window open when ctrl+click is
used, in case the user wants to open more links in new windows.

closes #18