### PR TITLE
colormode: Init with system theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,20 @@ body {
   display: flex;
 }
 
+@media (prefers-color-scheme: light) {
+  html,
+  body {
+    background-color: #fff;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  html,
+  body {
+    background-color: #20242c;
+  }
+}
+
 #root {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
Fixes a bug where the dark theme color mode would flash white when the extension was first opened. This uses the system color theme to pick a sensible default page color while we are still fetching the preferred color mode from browser storage.
