### PR TITLE
Make E2E tests faster in CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm install
 
       - name: Install Playwright browsers
-        run: pnpm playwright install --with-deps
+        run: pnpm playwright install chrome chromium --with-deps
 
       - name: Build for Chrome
         run: pnpm build:chrome

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,8 +21,7 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
- Only install necessary browsers in GitHub Actions.