### PR TITLE
fix: drag over empty hide last link logic

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -18,11 +18,12 @@ type CardProps = {
 };
 export function Card({ linkData, isInEditMode }: CardProps) {
   const { id, name, url } = linkData;
+  const item: CardDragItem = { id };
   const [isMouseOver, setIsMouseOver] = useBoolean();
   const [{ isDragEventInProgress }, drag] = useDrag(
     () => ({
       type: DragItemTypes.CARD,
-      item: { id },
+      item,
       isDragging: (monitor) => id === monitor.getItem().id,
       collect: (monitor) => ({
         isDragEventInProgress: !!monitor.getItem(),

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -40,7 +40,7 @@ export default function Cell({
     [isInEditMode, link]
   );
 
-  const [{ isOver }, drop] = useDrop(
+  const [{ dragItem, isOver }, drop] = useDrop(
     () => ({
       accept: DragItemTypes.CARD,
       hover: (item: CardDragItem) =>
@@ -55,6 +55,7 @@ export default function Cell({
         setStoredLinkKeys(state.linkKeys);
       },
       collect: (monitor) => ({
+        dragItem: monitor.getItem<CardDragItem>(),
         isOver: monitor.isOver(),
       }),
     }),
@@ -62,8 +63,12 @@ export default function Cell({
   );
 
   React.useEffect(() => {
-    isOver && !card ? setIsOverEmpty.on() : setIsOverEmpty.off();
-  }, [card, isOver, setIsOverEmpty]);
+    if (isOver && !card) {
+      setIsOverEmpty.on();
+    } else if (!dragItem) {
+      setIsOverEmpty.off();
+    }
+  }, [card, dragItem, isOver, setIsOverEmpty]);
 
   const deleteChildCard: React.MouseEventHandler = React.useCallback(
     (event) => {


### PR DESCRIPTION
Fixes a bug where dragging over an empty cell would sometimes cause the last link to appear, and sometimes cause it to be hidden. The intent is to hide the last link in this case.