### PR TITLE
fix(build): zip build directory contents

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -14,12 +14,13 @@ const zipPlugin = ({ target }: { target: Target }): Plugin => ({
    name: "zip",
    setup(build) {
       build.onEnd(() => {
-         execSync(`zip -r ${target}.zip ${target}`, { cwd: "dist" });
+         execSync(`zip -r ../${target}.zip *`, { cwd: `dist/${target}` });
       });
    },
 });
 
 execSync(`rm -rf dist/${target}`);
+execSync(`rm -f dist/${target}.zip`);
 
 esbuild({
    entryPoints: ["src/public/index.tsx"],


### PR DESCRIPTION
Zips only the build directory contents, and not the directory itself. Prevents a problem when uploading to firefox about manifest.json being at the root level of the extension.