### PR TITLE
feat: open popup shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "hop",
-   "version": "1.1.12",
+   "version": "1.1.13",
    "description": "An icon-first bookmark manager",
    "main": "src/public/index.tsx",
    "packageManager": "pnpm@7.5.2",

--- a/src/public/chrome/manifest.json
+++ b/src/public/chrome/manifest.json
@@ -19,5 +19,13 @@
       "48": "/icons/hop48.png",
       "128": "/icons/hop128.png"
    },
-   "permissions": ["storage", "tabs"]
+   "permissions": ["storage", "tabs"],
+   "commands": {
+      "_execute_action": {
+         "suggested_key": {
+            "default": "Alt+Shift+O"
+         },
+         "description": "Toggle Hop popup"
+      }
+   }
 }

--- a/src/public/chrome/manifest.json
+++ b/src/public/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
    "name": "Hop",
    "description": "An icon-first bookmark manager",
-   "version": "1.1.12",
+   "version": "1.1.13",
    "manifest_version": 3,
    "action": {
       "default_title": "Hop",

--- a/src/public/firefox/manifest.json
+++ b/src/public/firefox/manifest.json
@@ -13,6 +13,14 @@
       "96": "icon.svg"
    },
    "permissions": ["storage", "tabs"],
+   "commands": {
+      "_execute_browser_action": {
+         "suggested_key": {
+            "default": "Alt+Shift+O"
+         },
+         "description": "Toggle Hop popup"
+      }
+   },
    "browser_specific_settings": {
       "gecko": {
          "id": "hop@masonmcelvain.com"

--- a/src/public/firefox/manifest.json
+++ b/src/public/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
    "name": "Hop",
    "description": "An icon-first bookmark manager",
-   "version": "1.1.12",
+   "version": "1.1.13",
    "manifest_version": 2,
    "browser_action": {
       "default_title": "Hop",


### PR DESCRIPTION
Opens the popup via a keyboard shortcut.

Turns out that chrome does not support opening the popup via the api, despite `openPopup()` being documented as a stable api. https://github.com/GoogleChrome/developer.chrome.com/issues/2602

Instead, this keyboard shortcut can be configured in manifest.json. https://developer.chrome.com/docs/extensions/reference/commands/#action-commands