### PR TITLE
Migrate to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-strict-peer-dependencies=false

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
    "version": "1.1.16",
    "description": "An icon-first bookmark manager",
    "main": "src/public/index.tsx",
-   "packageManager": "pnpm@10.33.4",
+   "packageManager": "pnpm@11.1.2",
    "engines": {
       "node": "24.15.0"
    },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+allowBuilds:
+   esbuild: false
+   spawn-sync: false
+strictPeerDependencies: false


### PR DESCRIPTION
## Summary
- Bump `packageManager` to `pnpm@11.1.2`
- Move `strict-peer-dependencies` out of `.npmrc` into `pnpm-workspace.yaml` as `strictPeerDependencies` (v11 only reads auth/registry settings from `.npmrc`)
- Add an `allowBuilds` map for `esbuild` and `spawn-sync` (both `false`) to preserve v10's silent-ignore behavior — v11 now errors when build-script decisions are unresolved

## Test plan
- [ ] `pnpm install` runs without prompting or error
- [ ] `pnpm build` (chrome + firefox) succeeds
- [ ] `pnpm test` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)