### PR TITLE
Enforce 7-day Minimum Release Age for Dependencies

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ allowBuilds:
    esbuild: false
    spawn-sync: false
 strictPeerDependencies: false
+minimumReleaseAge: 10080

--- a/renovate.json
+++ b/renovate.json
@@ -9,5 +9,6 @@
    ],
    "rangeStrategy": "pin",
    "schedule": ["every weekend"],
-   "timezone": "America/Los_Angeles"
+   "timezone": "America/Los_Angeles",
+   "minimumReleaseAge": "7 days"
 }


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: 10080` (minutes) to `pnpm-workspace.yaml` so pnpm refuses to install dependency versions younger than 7 days.
- Add `minimumReleaseAge: "7 days"` to `renovate.json` so Renovate won't open update PRs for releases younger than 7 days.

Together these reduce exposure to supply chain attacks that depend on a freshly-published malicious version being pulled in before anyone notices.

## Test plan
- [ ] Renovate dashboard / next scheduled run reflects the new minimum age (no PRs opened for releases <7 days old).
- [ ] `pnpm install` still succeeds against the current lockfile.
- [ ] If a CVE patch needs to bypass the wait, confirm the documented escape hatch (per-package `packageRules` override in Renovate, or `--ignore-minimum-release-age` for pnpm) works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)